### PR TITLE
implement moving platform

### DIFF
--- a/moving_platform.gd
+++ b/moving_platform.gd
@@ -1,0 +1,20 @@
+extends Node2D
+
+# tween variables
+var tween = create_tween()
+var platform_time: float = 3.0
+
+@onready var platform_body = $platform_body
+# Referenced within the stage. Has to be set as a child of the platform in the stage scene
+@onready var move_point = $move_point
+
+func _ready() -> void:
+	# Queues up two tween animations into our one tween object, then sets them to be looped forever
+	# Moves from starting point to the GLOBAL position of the in-scene point
+	tween.tween_property(platform_body, "global_position", move_point.global_position, platform_time)
+	# Moves from the in-scene point back to the ORIGINAL ORIGIN of this platform.
+	tween.tween_property(platform_body, "global_position", self.global_position, platform_time)
+	tween.set_loops()
+	# We are only moving the platform's body, but not the origin point of the platform's scene.
+	# Global position is important, because the origin position of this scene is (0,0) while in another 
+	# scene its relative (or global) position is where we want to go.

--- a/moving_platform.tscn
+++ b/moving_platform.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=3 uid="uid://c0swbx71hxojj"]
+
+[ext_resource type="Script" path="res://moving_platform.gd" id="1_bbw2v"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_35so0"]
+size = Vector2(24, 8)
+
+[node name="moving_platform" type="Node2D"]
+script = ExtResource("1_bbw2v")
+
+[node name="platform_body" type="CharacterBody2D" parent="."]
+
+[node name="platform_shape" type="CollisionShape2D" parent="platform_body"]
+scale = Vector2(8, 8)
+shape = SubResource("RectangleShape2D_35so0")

--- a/water_and_air_level.tscn
+++ b/water_and_air_level.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=6 format=3 uid="uid://hc5vkc7fhhtr"]
+[gd_scene load_steps=7 format=3 uid="uid://hc5vkc7fhhtr"]
 
 [ext_resource type="PackedScene" uid="uid://da4ej7u0x7j44" path="res://water.tscn" id="1_k1mvy"]
 [ext_resource type="PackedScene" uid="uid://djurd6bltqyom" path="res://alien.tscn" id="2_ejw02"]
+[ext_resource type="PackedScene" uid="uid://c0swbx71hxojj" path="res://moving_platform.tscn" id="3_58sy0"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_1tr6l"]
 size = Vector2(1152, 328)
@@ -20,7 +21,7 @@ position = Vector2(576, 484)
 shape = SubResource("RectangleShape2D_1tr6l")
 
 [node name="Alien" parent="." instance=ExtResource("2_ejw02")]
-position = Vector2(200, 72)
+position = Vector2(416, 184)
 scale = Vector2(0.05, 0.05)
 
 [node name="StaticBody2D" type="StaticBody2D" parent="."]
@@ -50,3 +51,9 @@ debug_color = Color(0, 0.65112, 0.0330768, 0.42)
 position = Vector2(288, -72)
 shape = SubResource("RectangleShape2D_pa7c3")
 debug_color = Color(0, 0.65112, 0.0330768, 0.42)
+
+[node name="moving_platform" parent="." instance=ExtResource("3_58sy0")]
+position = Vector2(400, 256)
+
+[node name="move_point" type="Node2D" parent="moving_platform"]
+position = Vector2(656, -208)


### PR DESCRIPTION
Moving platform that is 1x3 tiles. Destination point is set in the scene the platform is added to, as a Node2D.

The platform will move back and forth between this Node2D position and its origin point at a determined tween speed.

# TODO
- Add asset for platform
- Figure out a way to let different platforms move at different speeds. Exported variable in moving_platform.gd??